### PR TITLE
WIP: Add support for Composite to the branch containing Abstract Zero support

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,131 +3,30 @@
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[CSTParser]]
-deps = ["Tokenize"]
-git-tree-sha1 = "60e9121d9ea044c30a04397e59b00c5d9eb826ee"
-uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "2.5.0"
-
 [[ChainRulesCore]]
 deps = ["MuladdMacro"]
 git-tree-sha1 = "8013d73583b79df2b5d8fc71e3c43f9246477fea"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 version = "0.9.7"
 
-[[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "215f1c81cfd1c5416cd78740bff8ef59b24cd7c0"
-uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.15.0"
-
-[[DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "65974157a18f4e19c07e5a94576328814ae23f9b"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.3"
-
-[[Dates]]
-deps = ["Printf"]
-uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-
-[[DelimitedFiles]]
-deps = ["Mmap"]
-uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
-[[InteractiveUtils]]
-deps = ["Markdown"]
-uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-
-[[LibGit2]]
-uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
-[[Libdl]]
-uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
-
-[[LinearAlgebra]]
-deps = ["Libdl"]
-uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-
-[[Logging]]
-uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
-
 [[MacroTools]]
-deps = ["CSTParser", "Compat", "DataStructures", "Test", "Tokenize"]
-git-tree-sha1 = "d6e9dedb8c92c3465575442da456aec15a89ff76"
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.1"
+version = "0.5.5"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[Mmap]]
-uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[MuladdMacro]]
 git-tree-sha1 = "c6190f9a7fc5d9d5915ab29f2134421b12d24a68"
 uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 version = "0.2.2"
 
-[[OrderedCollections]]
-git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.0"
-
-[[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
-uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-
-[[Printf]]
-deps = ["Unicode"]
-uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-
-[[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
-
 [[Random]]
 deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
-[[SHA]]
-uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
-
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[SharedArrays]]
-deps = ["Distributed", "Mmap", "Random", "Serialization"]
-uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
-
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-
-[[Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
-uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-
-[[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[[Tokenize]]
-git-tree-sha1 = "73c00ad506d88a7e8e4f90f48a70943101728227"
-uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.8"
-
-[[UUIDs]]
-deps = ["Random", "SHA"]
-uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-
-[[Unicode]]
-uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,21 +5,27 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[CSTParser]]
 deps = ["Tokenize"]
-git-tree-sha1 = "0ff80f68f55fcde2ed98d7b24d7abaf20727f3f8"
+git-tree-sha1 = "60e9121d9ea044c30a04397e59b00c5d9eb826ee"
 uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
-version = "0.6.1"
+version = "2.5.0"
+
+[[ChainRulesCore]]
+deps = ["MuladdMacro"]
+git-tree-sha1 = "8013d73583b79df2b5d8fc71e3c43f9246477fea"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "0.9.7"
 
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "215f1c81cfd1c5416cd78740bff8ef59b24cd7c0"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "2.1.0"
+version = "3.15.0"
 
 [[DataStructures]]
-deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "0809951a1774dc724da22d26e4289bbaab77809a"
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "65974157a18f4e19c07e5a94576328814ae23f9b"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.0"
+version = "0.18.3"
 
 [[Dates]]
 deps = ["Printf"]
@@ -63,14 +69,18 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MuladdMacro]]
+git-tree-sha1 = "c6190f9a7fc5d9d5915ab29f2134421b12d24a68"
+uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+version = "0.2.2"
+
 [[OrderedCollections]]
-deps = ["Random", "Serialization", "Test"]
-git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.1.0"
+version = "1.3.0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Test", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -111,9 +121,9 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[Tokenize]]
-git-tree-sha1 = "c8a8b00ae44a94950814ff77850470711a360225"
+git-tree-sha1 = "73c00ad506d88a7e8e4f90f48a70943101728227"
 uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
-version = "0.5.5"
+version = "0.5.8"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,12 @@ uuid = "700de1a5-db45-46bc-99cf-38207098b444"
 version = "0.2.0"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 
 [compat]
-julia = "1"
 MacroTools = "0.5"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -12,7 +12,7 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
     $gradtuple(x::Nothing) = nothing
-    $gradtuple(x::AbstractZero) = nothing
+    $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end
@@ -47,7 +47,7 @@ function gradm(ex, mut = false)
     $adj
     @inline function ZygoteRules._pullback($cx, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...))
-      $(mut ? nothing : :(back(::Nothing) = nothing))
+      $(mut ? nothing : :(back(::Nothing) = nothing)) # why is this neccessary? isn't this special case defined in gradtuple above?
       back(Δ) = $gradtuple(_back(Δ))
       return y, back
     end
@@ -57,7 +57,7 @@ function gradm(ex, mut = false)
       back(Δ) = $gradtuplekw(_back(Δ))
       return y, back
     end
-    nothing
+    nothing # why is this here?
   end
 end
 

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,5 +1,6 @@
 using MacroTools
 using MacroTools: @q, combinedef
+using ChainRulesCore: AbstractZero, Zero, DoesNotExist
 
 named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.args[1])) : arg
 
@@ -11,6 +12,7 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
     $gradtuple(x::Nothing) = nothing
+    $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -83,11 +83,11 @@ function gradm(ex, mut = false)
       return y, back
     end
     @inline function ZygoteRules._pullback($cx, $f::$T, $(args...)) where $(Ts...)
-        y, back = ZygoteRules._pullback_inner($cx, $f, $(args...))
+        y, back = ZygoteRules._pullback_inner($cx, $f, $(argnames...))
         return y, wrap(back)
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
-        y, back = ZygoteRule._pullback_inner($cx, $kT, kw, $f::$T, $(args...))
+        y, back = ZygoteRules._pullback_inner($cx, $kT, kw, $f::$T, $(argnames...))
         return y, wrap(back)
     end
     nothing # why is this here?

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -68,13 +68,15 @@ function gradm(ex, mut = false)
     @inline function ZygoteRules._pullback($cx, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...))
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
-      back(Δ) = $gradtuple(nothings2zeros(_back(zeros2nothings(Δ))))
+      #back(Δ) = $gradtuple(nothings2zeros(_back(zeros2nothings(Δ))))
+      back(Δ) = $gradtuple(nothings2zeros(_back(Δ)))
       return y, back
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...); kw...)
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
-      back(Δ) = $gradtuplekw(nothings2zeros(_back(zeros2nothings(Δ))))
+      #back(Δ) = $gradtuplekw(nothings2zeros(_back(zeros2nothings(Δ))))
+      back(Δ) = $gradtuplekw(nothings2zeros(_back(Δ)))
       return y, back
     end
     nothing # why is this here?

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -33,7 +33,6 @@ for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
-    $gradtuple(x::Nothing) = Zero()
     $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -7,19 +7,19 @@ named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.
 typeless(x) = MacroTools.postwalk(x -> isexpr(x, :(::), :kw) ? x.args[1] : x, x)
 isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 
-function legacytype_error()
+function legacytype_warn()
   # can't use logging macros as that breaks nested AD.
-  println("Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
+  Core.println("Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
   for (ii, callsite) in enumerate(stacktrace())
-    println("[$ii] $callsite")
+    Core.println("[$ii] $callsite")
   end
 end
 
 function difftype_error()
   # can't use logging macros as that breaks nested AD.
-  println("AbstractZero passed when Nothing expected. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
+  Core.println("AbstractZero passed when Nothing expected. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
   for (ii, callsite) in enumerate(stacktrace())
-    println("[$ii] $callsite")
+    Core.println("[$ii] $callsite")
   end
 end
 
@@ -41,7 +41,7 @@ Convert input `x` from the ChainRules differential types to the legacy ZygoteRul
 differential2legacy(x) = x
 differential2legacy(::AbstractZero) = nothing
 differential2legacy(t::Union{Tuple, NamedTuple}) = map(differential2legacy, t)
-differential2legacy(::Nothing) = (legacytype_error(); return nothing)
+differential2legacy(::Nothing) = (legacytype_warn(); return nothing)
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -10,7 +10,7 @@ isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
-    $gradtuple(x::Tuple) = ($(ntuple(_->:(Zero()),n)...), x...)
+    $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::Nothing) = Zero()
     $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -32,9 +32,9 @@ end
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
-    $gradtuple(x::Composite{Any, T} where T<:Tuple) =  ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::AbstractZero) = x
+    $gradtuple(x::Composite{Any, T} where T<:Tuple) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -34,7 +34,6 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::AbstractZero) = x
-    $gradtuple(x::Composite{Any, T} where T<:Tuple) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,6 +1,6 @@
 using MacroTools
 using MacroTools: @q, combinedef
-using ChainRulesCore: AbstractZero, Zero, DoesNotExist, Composite
+using ChainRulesCore: AbstractZero, Zero, DoesNotExist, Composite, unthunk
 
 named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.args[1])) : arg
 
@@ -10,23 +10,47 @@ isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 """
     generic2diff(x)
 
-Convert input `x` from the legacy ZygoteRules format to the ChainRules differential types.
+Convert input `x` from the legacy Zygote format to the ChainRules differential types.
+Zygote used to use tuples to represent both a collection of gradients w.r.t. a number of
+arguments but also to represent the gradient of a tuple. This means that the gradients
+w.r.t a tuple and a scalar would be represented as ((gt1, gt2, gt3), gs). The wrapper
+function `generic2diff` takes care of the collection, while a gradient w.r.t. to a tuple
+is taken care of by g2d to be represented as a ChainRules.Composite type.
 """
-generic2diff(x) = x
+generic2diff(x) = error("Gradient $x should be a tuple")
 generic2diff(::Nothing) = Zero()
-generic2diff(t::Union{Tuple, NamedTuple}) = map(generic2diff, t)
+generic2diff(x::Union{AbstractZero, Composite}) = x # TODO: remove this once complete (shouldnt happen?)
+generic2diff(t::Tuple) = map(g2d, t)
+
+g2d(x) = x
+g2d(::Nothing) = Zero()
+function g2d(t::Union{Tuple, NamedTuple})
+  tp = map(g2d, t)
+  Composite{Any, typeof(tp)}(tp)
+end
 
 """
     diff2generic(x)
 
 Convert input `x` from the ChainRules differential types to the legacy ZygoteRules format.
 """
-diff2generic(x) = x
+diff2generic(x) = unthunk(x)
 diff2generic(::AbstractZero) = nothing
 diff2generic(t::Union{Tuple, NamedTuple}) = map(diff2generic, t)
 function diff2generic(::Nothing)
     @error "Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message"  stacktrace=stacktrace()
     return nothing
+end
+#diff2generic(x::Tuple{Vararg{AbstractZero}}) = Zero() # TODO should this happen?
+diff2generic(t::Union{Tuple, NamedTuple}) = map(diff2generic, t)
+for T_outer in (:Tuple, :NamedTuple)
+  # we create separate methods rather than using a `Union` + an `if` so that we avoid a
+  # branch that changes output type, because nested AD on that kinda thing makes Zygote less
+  # than happy.
+  @eval @inline function diff2generic(x::Composite{P, T}) where {P, T<:$T_outer}
+    xp = map(diff2generic, x)
+    convert($T_outer, xp)
+  end
 end
 
 for n = 0:3
@@ -34,6 +58,7 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::AbstractZero) = x
+    $gradtuple(x::Composite) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -87,7 +87,7 @@ function gradm(ex, mut = false)
         return y, wrap(back)
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
-        y, back = ZygoteRules._pullback_inner($cx, $kT, kw, $f::$T, $(argnames...))
+        y, back = ZygoteRules._pullback_inner($cx, $kT, $f::$T, $(argnames...); kw...)
         return y, wrap(back)
     end
     nothing # why is this here?

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -34,7 +34,7 @@ w.r.t a tuple and a scalar would be represented as ((gt1, gt2, gt3), gs). The wr
 function `legacy2differential` takes care of the collection, while a gradient w.r.t. to a
 tuple is taken care of by l2d to be represented as a ChainRules.Composite type.
 """
-legacy2differential(x) = error("Gradient $x should be a tuple")
+legacy2differential(x) = x
 legacy2differential(::Nothing) = Zero()
 legacy2differential(x::Union{AbstractZero, Composite}) = (difftype_error(); return x)
 legacy2differential(t::Tuple) = map(l2d, t)
@@ -42,7 +42,7 @@ legacy2differential(t::Tuple) = map(l2d, t)
 l2d(x) = x
 l2d(::Nothing) = Zero()
 function l2d(t::Union{Tuple, NamedTuple})
-  tp = map(g2d, t)
+  tp = map(l2d, t)
   return Composite{Any, typeof(tp)}(tp)
 end
 
@@ -60,8 +60,8 @@ for T_outer in (:Tuple, :NamedTuple)
   # we create separate methods rather than using a `Union` + an `if` so that we avoid a
   # branch that changes output type, because nested AD on that kinda thing makes Zygote less
   # than happy.
-  @eval @inline function diff2generic(x::Composite{P, T}) where {P, T<:$T_outer}
-    xp = map(diff2generic, x)
+  @eval @inline function differential2legacy(x::Composite{P, T}) where {P, T<:$T_outer}
+    xp = map(differential2legacy, x)
     convert($T_outer, xp)
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -1,6 +1,6 @@
 using MacroTools
 using MacroTools: @q, combinedef
-using ChainRulesCore: AbstractZero, Zero, DoesNotExist
+using ChainRulesCore: AbstractZero, Zero, DoesNotExist, Composite
 
 named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.args[1])) : arg
 
@@ -34,6 +34,8 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::AbstractZero) = x
+    $gradtuple(x::Composite{Any, T} where T<:Union{Tuple, NamedTuple}) = x # see x::Tuple case above. Should this add Zero()s? I don't think so,
+        # it looks like above is catching multiple gradients (wrt a function, kwargs, kwfunc), not a struct
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -18,15 +18,8 @@ Wraps the back function in a `nothings2zeros` function, which replaces the `noth
 `Zero()`s.
 """
 function wrap(back)
-    #println("wrap called")
     function wrapped_back(Δ)
-        #println("wrapped_back called")
-        #println(Δ)
-        intermediate = back(Δ)
-        #println(intermediate)
-        output = nothings2zeros(intermediate)
-        #println(output)
-        return output
+        return nothings2zeros(back(Δ))
     end
     return wrapped_back
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -47,13 +47,13 @@ function gradm(ex, mut = false)
     $adj
     @inline function ZygoteRules._pullback($cx, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...))
-      $(mut ? nothing : :(back(::Nothing) = nothing)) # why is this neccessary? isn't this special case defined in gradtuple above?
+      $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
       back(Δ) = $gradtuple(_back(Δ))
       return y, back
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...); kw...)
-      $(mut ? nothing : :(back(::Nothing) = nothing))
+      $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
       back(Δ) = $gradtuplekw(_back(Δ))
       return y, back
     end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -8,24 +8,29 @@ typeless(x) = MacroTools.postwalk(x -> isexpr(x, :(::), :kw) ? x.args[1] : x, x)
 isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 
 """
-    generic2diff(x)
+    legacy2differential(x)
 
 Convert input `x` from the legacy ZygoteRules format to the ChainRules differential types.
 """
-generic2diff(x) = x
-generic2diff(::Nothing) = Zero()
-generic2diff(t::Union{Tuple, NamedTuple}) = map(generic2diff, t)
+legacy2differential(x) = x
+legacy2differential(::Nothing) = Zero()
+legacy2differential(t::Union{Tuple, NamedTuple}) = map(legacy2differential, t)
 
 """
-    diff2generic(x)
+    differential2legacy(x)
 
 Convert input `x` from the ChainRules differential types to the legacy ZygoteRules format.
 """
-diff2generic(x) = x
-diff2generic(::AbstractZero) = nothing
-diff2generic(t::Union{Tuple, NamedTuple}) = map(diff2generic, t)
-function diff2generic(::Nothing)
-    @error "Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message"  stacktrace=stacktrace()
+differential2legacy(x) = x
+differential2legacy(::AbstractZero) = nothing
+differential2legacy(t::Union{Tuple, NamedTuple}) = map(differential2legacy, t)
+function differential2legacy(::Nothing)
+    # can't use logging macros as that breaks nested AD.
+    println("Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
+    for (ii, callsite) in enumerate(stacktrace())
+      ii > 10 && break
+      println("[$ii] $callsite")
+    end
     return nothing
 end
 
@@ -69,18 +74,18 @@ function gradm(ex, mut = false)
     @inline function ZygoteRules._pullback($cx, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...))
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
-      #back(Δ) = $gradtuple(generic2diff(_back(diff2generic(Δ))))
-      back(Δ) = $gradtuple(generic2diff(_back(Δ)))
+      back(Δ) = $gradtuple(legacy2differential(_back(differential2legacy(Δ))))
+      #back(Δ) = $gradtuple(legacy2differential(_back(Δ)))
       return y, back
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...); kw...)
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
-      #back(Δ) = $gradtuplekw(generic2diff(_back(diff2generic(Δ))))
-      back(Δ) = $gradtuplekw(generic2diff(_back(Δ)))
+      back(Δ) = $gradtuplekw(legacy2differential(_back(differential2legacy(Δ))))
+      #back(Δ) = $gradtuplekw(legacy2differential(_back(Δ)))
       return y, back
     end
-    nothing # why is this here?
+    return nothing  # make nothing show in terminal after using macro
   end
 end
 

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -32,10 +32,9 @@ end
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
+    $gradtuple(x::Composite{Any, T} where T<:Tuple) =  ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::Tuple) = ($(ntuple(_->:(DoesNotExist()),n)...), x...)
     $gradtuple(x::AbstractZero) = x
-    $gradtuple(x::Composite{Any, T} where T<:Union{Tuple, NamedTuple}) = x # see x::Tuple case above. Should this add Zero()s? I don't think so,
-        # it looks like above is catching multiple gradients (wrt a function, kwargs, kwfunc), not a struct
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -15,6 +15,7 @@ Convert input `x` from the internal Zygote format to the ChainRules differential
 nothings2zeros(x) = x
 nothings2zeros(::Nothing) = Zero()
 nothings2zeros(t::Tuple) = map(nothings2zeros, t)
+nothings2zeros(nt::NamedTuple) = map(nothings2zeros, nt)
 
 """
     zeros2nothings(x)
@@ -24,6 +25,7 @@ Convert input `x` from the ChainRules differential types to the internal Zygote 
 zeros2nothings(x) = x
 zeros2nothings(::AbstractZero) = nothing
 zeros2nothings(t::Tuple) = map(zeros2nothings, t)
+zeros2nothings(nt::NamedTuple) = map(zeros2nothings, nt)
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -7,7 +7,7 @@ named(arg) = isexpr(arg, :(::)) && length(arg.args) == 1 ? :($(gensym())::$(arg.
 typeless(x) = MacroTools.postwalk(x -> isexpr(x, :(::), :kw) ? x.args[1] : x, x)
 isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 
-function difftype_error()
+function legacytype_error()
   # can't use logging macros as that breaks nested AD.
   println("Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
   for (ii, callsite) in enumerate(stacktrace())
@@ -41,7 +41,7 @@ Convert input `x` from the ChainRules differential types to the legacy ZygoteRul
 differential2legacy(x) = x
 differential2legacy(::AbstractZero) = nothing
 differential2legacy(t::Union{Tuple, NamedTuple}) = map(differential2legacy, t)
-differential2legacy(::Nothing) = (difftype_error(); return nothing)
+differential2legacy(::Nothing) = (legacytype_error(); return nothing)
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -15,7 +15,7 @@ function legacytype_error()
   end
 end
 
-function difftype_error2()
+function difftype_error()
   # can't use logging macros as that breaks nested AD.
   println("AbstractZero passed when Nothing expected. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message. \n Stacktrace:")
   for (ii, callsite) in enumerate(stacktrace())
@@ -30,7 +30,7 @@ Convert input `x` from the legacy ZygoteRules format to the ChainRules different
 """
 legacy2differential(x) = x
 legacy2differential(::Nothing) = Zero()
-#legacy2differential(x::AbstractZero) = (difftype_error2(); return x)
+#legacy2differential(x::AbstractZero) = (difftype_error(); return x)
 legacy2differential(t::Union{Tuple, NamedTuple}) = map(legacy2differential, t)
 
 """

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -11,7 +11,7 @@ for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
-    $gradtuple(x::Nothing) = nothing
+    $gradtuple(x::Nothing) = Zero()
     $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -43,6 +43,8 @@ function adjoint end
 function _pullback end
 function pullback end
 
+say(x) = (println("say ", x); return x)
+
 function gradm(ex, mut = false)
   @capture(shortdef(ex), (name_(args__) = body_) |
                          (name_(args__) where {Ts__} = body_)) || error("Need a function definition")
@@ -70,14 +72,14 @@ function gradm(ex, mut = false)
       y, _back = adjoint(__context__, $f, $(argnames...))
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
       #back(Δ) = $gradtuple(generic2diff(_back(diff2generic(Δ))))
-      back(Δ) = $gradtuple(generic2diff(_back(Δ)))
+      back(Δ) = $gradtuple(say(generic2diff(say(_back(Δ)))))
       return y, back
     end
     @inline function ZygoteRules._pullback($cx, ::$kT, kw, $f::$T, $(args...)) where $(Ts...)
       y, _back = adjoint(__context__, $f, $(argnames...); kw...)
       $(mut ? nothing : :(back(::Union{Nothing,AbstractZero}) = Zero()))
       #back(Δ) = $gradtuplekw(generic2diff(_back(diff2generic(Δ))))
-      back(Δ) = $gradtuplekw(generic2diff(_back(Δ)))
+      back(Δ) = $gradtuplekw(say(generic2diff(say(_back(Δ)))))
       return y, back
     end
     nothing # why is this here?

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -14,8 +14,7 @@ Convert input `x` from the internal Zygote format to the ChainRules differential
 """
 nothings2zeros(x) = x
 nothings2zeros(::Nothing) = Zero()
-nothings2zeros(t::Tuple) = map(nothings2zeros, t)
-nothings2zeros(nt::NamedTuple) = map(nothings2zeros, nt)
+nothings2zeros(t::Union{Tuple, NamedTuple}) = map(nothings2zeros, t)
 
 """
     zeros2nothings(x)
@@ -24,8 +23,7 @@ Convert input `x` from the ChainRules differential types to the internal Zygote 
 """
 zeros2nothings(x) = x
 zeros2nothings(::AbstractZero) = nothing
-zeros2nothings(t::Tuple) = map(zeros2nothings, t)
-zeros2nothings(nt::NamedTuple) = map(zeros2nothings, nt)
+zeros2nothings(t::Union{Tuple, NamedTuple}) = map(zeros2nothings, t)
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -24,6 +24,10 @@ Convert input `x` from the ChainRules differential types to the internal Zygote 
 zeros2nothings(x) = x
 zeros2nothings(::AbstractZero) = nothing
 zeros2nothings(t::Union{Tuple, NamedTuple}) = map(zeros2nothings, t)
+zeros2nothings(::Nothing) =
+    @warn "Use of 'nothing' to represent zero gradients is deprecated, " *
+    "use Zero() or DoesNotExist() from ChainRules";
+    nothing
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -65,17 +65,6 @@ for T_outer in (:Tuple, :NamedTuple)
     convert($T_outer, xp)
   end
 end
-#diff2generic(x::Tuple{Vararg{AbstractZero}}) = Zero() # TODO should this happen?
-diff2generic(t::Union{Tuple, NamedTuple}) = map(diff2generic, t)
-for T_outer in (:Tuple, :NamedTuple)
-  # we create separate methods rather than using a `Union` + an `if` so that we avoid a
-  # branch that changes output type, because nested AD on that kinda thing makes Zygote less
-  # than happy.
-  @eval @inline function diff2generic(x::Composite{P, T}) where {P, T<:$T_outer}
-    xp = map(diff2generic, x)
-    convert($T_outer, xp)
-  end
-end
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
@@ -91,8 +80,6 @@ abstract type AContext end
 function adjoint end
 function _pullback end
 function pullback end
-
-say(x) = (println("say ", x); return x)
 
 function gradm(ex, mut = false)
   @capture(shortdef(ex), (name_(args__) = body_) |

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -10,7 +10,7 @@ isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 """
     generic2diff(x)
 
-Convert input `x` from the internal Zygote format to the ChainRules differential types.
+Convert input `x` from the legacy ZygoteRules format to the ChainRules differential types.
 """
 generic2diff(x) = x
 generic2diff(::Nothing) = Zero()
@@ -19,15 +19,15 @@ generic2diff(t::Union{Tuple, NamedTuple}) = map(generic2diff, t)
 """
     diff2generic(x)
 
-Convert input `x` from the ChainRules differential types to the internal Zygote format.
+Convert input `x` from the ChainRules differential types to the legacy ZygoteRules format.
 """
 diff2generic(x) = x
 diff2generic(::AbstractZero) = nothing
 diff2generic(t::Union{Tuple, NamedTuple}) = map(diff2generic, t)
-diff2generic(::Nothing) =
-    @warn "Use of 'nothing' to represent zero gradients is deprecated, " *
-    "use Zero() or DoesNotExist() from ChainRules";
-    nothing
+function diff2generic(::Nothing)
+    @error "Zygote internal use  of 'nothing', rather than `AbstractZero`, detected.  This should never occur. Please open an issue on https://github.com/FluxML/Zygote.jl/issues, including the full text of this message"  stacktrace=stacktrace()
+    return nothing
+end
 
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -12,7 +12,7 @@ for n = 0:3
   @eval begin
     $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
     $gradtuple(x::Nothing) = nothing
-    $gradtuple(x::AbstractZero) = x
+    $gradtuple(x::AbstractZero) = nothing
     $gradtuple(x) = error("Gradient $x should be a tuple")
   end
 end

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -10,7 +10,7 @@ isvararg(x) = isexpr(x, :(::)) && namify(x.args[2]) == :Vararg
 for n = 0:3
   gradtuple = Symbol(:gradtuple, n)
   @eval begin
-    $gradtuple(x::Tuple) = ($(ntuple(_->:nothing,n)...), x...)
+    $gradtuple(x::Tuple) = ($(ntuple(_->:(Zero()),n)...), x...)
     $gradtuple(x::Nothing) = Zero()
     $gradtuple(x::AbstractZero) = x
     $gradtuple(x) = error("Gradient $x should be a tuple")

--- a/src/adjoint.jl
+++ b/src/adjoint.jl
@@ -30,7 +30,7 @@ Convert input `x` from the legacy ZygoteRules format to the ChainRules different
 """
 legacy2differential(x) = x
 legacy2differential(::Nothing) = Zero()
-#legacy2differential(x::AbstractZero) = (difftype_error(); return x)
+legacy2differential(x::AbstractZero) = (difftype_error(); return x)
 legacy2differential(t::Union{Tuple, NamedTuple}) = map(legacy2differential, t)
 
 """


### PR DESCRIPTION
This changes the `@adjoint` macro such that outputs are converted to Composite.

See also https://github.com/mzgubic/Zygote.jl/pull/1